### PR TITLE
Deleting runs updates plan and daily stats documents appropriately

### DIFF
--- a/auth/login.js
+++ b/auth/login.js
@@ -18,11 +18,17 @@ const login = async (req, res) => {
       // Transform the user response from Mongoose into a plain object with only the public info
       // as visible fields
       const payload = {
-        id: user._id,
+        _id: user._id,
         email: user.email,
         name: user.name,
         hasFitbitAuth: user.hasFitbitAuth || false,
         hasStravaAuth: user.hasStravaAuth || false,
+        stats: {
+          weekStartsOn: user.weekStartsOn,
+        },
+        gear: {
+          shoes: user.gear.shoes,
+        }
       }
 
       // TODO: Generate JWT for public user data and send back as bearer token

--- a/dailyStats/getAllDailyStats.js
+++ b/dailyStats/getAllDailyStats.js
@@ -2,7 +2,7 @@ import DailyStatsModel from '../db/DailyStatsModel.js'
 
 // Returns the logged in user's runs from the database.
 const getAllDailyStats = async (req, res) => {
-  const dailyStatsArray = await DailyStatsModel.find({ userId: req.user.id }).lean()
+  const dailyStatsArray = await DailyStatsModel.find({ userId: req.user._id }).lean()
 
   // Turn it into a map like { dateStr: { key1: val1 } } so lookups by date are faster.
   const dailyStatsMap = {}

--- a/dailyStats/resetDailyStats.js
+++ b/dailyStats/resetDailyStats.js
@@ -1,0 +1,166 @@
+import { DateTime } from 'luxon'
+import RunModel from '../db/RunModel.js'
+import DailyStatsModel from '../db/DailyStatsModel.js'
+import addFloats from '../utils/addFloats.js'
+
+// Deletes all existing DailyStats objects for this user and creates new ones that represent the
+// distances for each date that a run exists for that user.
+const resetDailyStats = async (user, isVerboseLogging) => {
+  const userId = user._id
+
+  if (isVerboseLogging) {
+    console.log(`Resetting DailyStats for user: ${userId}`)
+    console.dir(user)
+  }
+
+  await DailyStatsModel.deleteMany(
+    { userId: userId }
+  )
+
+  let allRuns
+  try {
+    allRuns = await RunModel.find(
+      { userId: userId }, // all runs for this user
+      '_id startDate timezone distance title'
+    ).lean()
+  } catch (err) {
+    if (isVerboseLogging) {
+      console.error(err)
+    }
+    throw err
+  }
+
+  if (isVerboseLogging) {
+    console.log(`Found ${allRuns.length} runs for user`)
+  }
+
+  // Add a DailyStats document for each unique date with a run, and populate the DailyStats fields
+  // with correct distance totals and runIds
+  let dailyStats = {}
+  for (let j = 0; j < allRuns.length; j++) {
+    let run = allRuns[j]
+
+    // Timezone field has a weird format like "(GMT-07:00) America/Denver", just ignore the offset
+    const tz = run.timezone.split(' ')[1]
+
+    // Convert the run's full timestamp into a simpler yyyy-mm-dd date string
+    const startDate = DateTime.fromJSDate(run.startDate, { zone: tz }).toISODate()
+
+    // Is there is a DailyStats object with this run's startDate already?
+    if (Object.keys(dailyStats).includes(startDate)) {
+      // Add the distance to the existing distance for today
+      dailyStats[startDate] = {
+        ...dailyStats[startDate],
+        distance: addFloats(dailyStats[startDate].distance, run.distance),
+        title: 'Multiple runs',
+        runIds: [
+          ...dailyStats[startDate].runIds,
+          run._id
+        ]
+      }
+    } else {
+      // Make a new entry for this date and set the distance field appropriately
+      dailyStats[startDate] = {
+        userId: userId,
+        date: startDate,
+        distance: run.distance,
+        title: run.title,
+        runIds: [run._id],
+
+        // Add these fields later when we know which dates exist and their daily distance totals
+        sevenDayDistance: 0,
+        weeklyDistance: 0,
+      }
+    }
+  }
+
+  // Determine 7day distance
+  //   - Today's distance + all of the previous day's distances until 6 days ago (inclusive)
+  // Determine weekly distance
+  //   - Today's distance + all of the previous day's distances until the first day of the week (inclusive) as 
+  //     determined by the user.stats.weekStartsOn field
+
+  if (isVerboseLogging) {
+    console.log(`User's week starts on: ${user.stats.weekStartsOn}`)
+    console.log('~~~~~~~~~~~~~~~~~~~~~')
+  }
+
+  // Using the existing daily distance totals, calculate the derivative distance fields
+  const dates = Object.keys(dailyStats)
+  for (let i = 0; i < dates.length; i++) {
+    // "Current" date refers to the date whose 7day and weekly distances we want to find
+    const currentDailyStats = dailyStats[dates[i]]
+    const currentDate = DateTime.fromISO(currentDailyStats.date)
+    let hitStartOfWeek = currentDate.weekday === user.stats.weekStartsOn // Set to true once first day of this week is found
+
+    if (isVerboseLogging) {
+      console.log(`DailyStats date: ${dates[i]}`)
+      console.log(`weekday: ${currentDate.weekday}`)
+      console.log('~~~~~~~~~~~~~~~~~~~~~')
+    }
+    
+
+    // Values we're trying to calculate
+    currentDailyStats.sevenDayDistance = currentDailyStats.distance
+    currentDailyStats.weeklyDistance = currentDailyStats.distance
+
+    // Find the 6 previous days (-1 to -6) based on the current date we're looking at
+    for (let dayOffset = 1; dayOffset <= 6; dayOffset++) {
+      let date = currentDate.minus({ day: dayOffset })
+      const dateStr = date.toISODate()
+
+      if (isVerboseLogging) {
+        console.log(`date: ${dateStr} / weekday: ${date.weekday}`)
+      }
+
+      // Does a dailyStats record exist for this date?
+      if (dailyStats[dateStr] != null) {
+        // 7-day distance is just the sum of all distance for previous 6 days
+        if (isVerboseLogging) {
+          console.log('    adding to 7day total')
+        }
+        currentDailyStats.sevenDayDistance += dailyStats[dateStr].distance
+
+        // Have we hit the start of this week yet? If so, do not add this to the weekly distance
+        if (!hitStartOfWeek) {
+          if (isVerboseLogging) {
+            console.log('    adding to weekly total')
+          }
+
+          // Update the halting flag, then add this date's distance to the weekly sum.
+          hitStartOfWeek = date.weekday === user.stats.weekStartsOn
+          currentDailyStats.weeklyDistance += dailyStats[dateStr].distance
+        }
+      } else if (!hitStartOfWeek) {
+        // Even if the dailyStats object doesn't exist, we should see if this date is the first
+        // one of the week.
+        hitStartOfWeek = date.weekday === user.stats.weekStartsOn
+      }
+    }
+  }
+
+  if (isVerboseLogging) {
+    console.log('\n\n\n')
+    console.log('Inserting DS into mongo for this user:')
+  }
+
+  for (let ds of Object.values(dailyStats)) {
+    // Insert the user's DailyStats documents to the collection
+    try {
+      // Bulk insert all of the DailyStats objects you made out of the runs
+      if (isVerboseLogging) {
+        console.log(ds.date)
+      }
+      await DailyStatsModel.insertMany(ds)
+    } catch (err) {
+      if (isVerboseLogging) {
+        console.error('Failed to insert this ds:')
+        console.dir(ds)
+        console.error(err)
+      }
+      throw err
+    } 
+  }
+}
+
+export default resetDailyStats

--- a/dailyStats/updateDailyStats.js
+++ b/dailyStats/updateDailyStats.js
@@ -2,23 +2,6 @@ import { DateTime } from 'luxon'
 import DailyStatsModel from '../db/DailyStatsModel.js'
 import getWeekDates from './getWeekDates.js'
 
-// TODO: Test cases to implement:
-// 1. Add a run that is later than every existing run
-//   - This will be the most common scenario (new run happens today, is synced right after)
-// 2. Add a run that is later than some runs in a week, but not the latest.
-//   - E.g. Multiple runs added back to back, but later run is added before an earlier one in the same week
-// 3. Add a run that has no other runs in the same week or within seven days
-//   - E.g. The user takes a break from running for a while. Only this DS document should be affected.
-// 4. Add a run that occurs before and after existing runs
-//   - E.g. Something went wrong and we went to resync Strava runs, and now we're adding a run far in the past
-//
-// Test framework:
-// - Generate a set of DailyStats and Run documents to populate a test database
-// - Attempt to add another run via stravaWebhookHandler.js
-// - This function gets called for a new run
-// - Validate that the database has exactly the new contents we anticipate, given the new run's date
-//   and the Runs/DailyStats we populated the test database with.
-
 // Either create a new DailyStats document for this date, or look up the existing DailyStats
 // document for this date and add distances and this runId to the document.
 //

--- a/dailyStats/updateDailyStats.test.js
+++ b/dailyStats/updateDailyStats.test.js
@@ -7,29 +7,6 @@ import { describe, expect, beforeAll, afterEach, afterAll, test } from '@jest/gl
 
 import updateDailyStats from './updateDailyStats.js'
 
-// TODO: Test cases to implement:
-// 1. Add a run that is later than every existing run
-//   - This will be the most common scenario (new run happens today, is synced right after)
-// 2. Add a run that is later than some runs in a week, but not the latest.
-//   - E.g. Multiple runs added back to back, but later run is added before an earlier one in the same week
-// 3. Add a run that has no other runs in the same week or within seven days
-//   - E.g. The user takes a break from running for a while. Only this DS document should be affected.
-// 4. Add a run that occurs before and after existing runs
-//   - E.g. Something went wrong and we went to resync Strava runs, and now we're adding a run far in the past
-//
-// Test framework:
-// - Generate a set of DailyStats and Run documents to populate a test database
-// - Attempt to add another run via stravaWebhookHandler.js
-// - This function gets called for a new run
-// - Validate that the database has exactly the new contents we anticipate, given the new run's date
-//   and the Runs/DailyStats we populated the test database with.
-
-
-// STEP 1: Able to add a DailyStats document to the test db
-// - Set up test db
-// - Add DailyStats to DB, validate
-// - Tear down db
-
 beforeAll(async () => {
   // Set up test DB
   try {

--- a/runs/deleteRun.js
+++ b/runs/deleteRun.js
@@ -1,6 +1,8 @@
 import mongoose from 'mongoose'
 import RunModel from '../db/RunModel.js'
 
+import resetDailyStats from '../dailyStats/resetDailyStats.js'
+import addRunDistanceToPlans from './addRunDistanceToPlans.js'
 
 // Removes the given run from the database
 const deleteRun = async (req, res) => {
@@ -14,6 +16,12 @@ const deleteRun = async (req, res) => {
 
     await RunModel.deleteOne({_id: mongoose.Types.ObjectId(req.params.id)})
     console.log(`Deleted run with id "${req.params.id}"`)
+
+    // Correct the distances in DS now that run is deleted
+    await resetDailyStats(req.user)
+
+    // Update the plan distances once DS is correct.
+    await addRunDistanceToPlans(run, req.user)
 
     return res.json(run)
   } catch (e) {

--- a/runs/deleteRun.test.js
+++ b/runs/deleteRun.test.js
@@ -1,0 +1,176 @@
+import mongoose from 'mongoose'
+import TrainingModel from '../db/TrainingModel.js'
+import DailyStatsModel from '../db/DailyStatsModel.js'
+import RunModel from '../db/RunModel.js'
+import UserModel from '../db/UserModel.js'
+import { jest, describe, expect, beforeAll, beforeEach, afterEach, afterAll, test } from '@jest/globals'
+
+import deleteRun from './deleteRun.js'
+
+beforeAll(async () => {
+  // Set up test DB
+  try {
+    await mongoose.connect('mongodb://localhost/deleteRun', {
+      useNewUrlParser: true,
+      useUnifiedTopology: true
+    })
+  } catch (err) {
+    console.error('Failed to connect to Mongoose')
+    console.dir(err)
+  }
+})
+
+beforeEach(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {}) // Ignores console.log, keeps others
+})
+
+afterEach(async () => {
+  // Clean out the db after each test run
+  await TrainingModel.deleteMany()
+  await UserModel.deleteMany()
+  await RunModel.deleteMany()
+  await DailyStatsModel.deleteMany()
+})
+
+afterAll(async () => {
+  // Tear down test DB
+  return await mongoose.connection.close()
+})
+
+describe('Run deletion', () => {
+  test('Delete a single run', async () => {
+    const user = await UserModel.create({
+      name: 'Vlad',
+      email: 'lenin@gmail.com'
+    })
+
+    const run = await RunModel.create({
+      userId: user._id,
+      name: 'Test Run 1',
+      startDate: new Date('2022-10-03T23:07:39Z'), // first day of plan
+      startDateLocal: new Date('2022-10-03T17:07:39Z'),
+      timezone: '(GMT-06:00) America/Chicago',
+      distance: 1609.34, // 1 mile, in meters
+    })
+
+    // Existing DS document
+    await DailyStatsModel.create({
+      userId: user._id,
+      date: '2022-10-03',
+      distance: 1609.34,
+      runIds: [run._id],
+    })
+
+    await TrainingModel.create({
+      userId: user._id,
+      startDate: '2022-10-03',
+      endDate: '2022-10-09',
+      timezone: 'America/Denver',
+      title: 'Training Plan 1 Week',
+      goal: 'Delete run inside training plans without bugs :)',
+      isActive: true,
+      actualDistance: 1609.34, // 1 mile, in meters
+      plannedDistance: 1,
+      plannedDistanceMeters: 1609.34, // 1 mile, in meters
+      weeks: [{
+        startDateISO: '2022-10-03',
+        actualDistance: 1609.34, // 1 mile, in meters
+        plannedDistance: 1,
+        plannedDistanceMeters: 1609.34, // 1 mile, in meters
+      }],
+      dates: [
+        {
+          dateISO: '2022-10-03',
+          actualDistance: 1609.34, // 1 mile, in meters
+          plannedDistance: 1,
+          plannedDistanceMeters: 1609.34, // 1 mile, in meters
+          workout: '',
+          workoutCategory: 1, // Easy
+        },
+        {
+          dateISO: '2022-10-04',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-05',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-06',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-07',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-08',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-09',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        }
+      ],
+      journal: []
+    })
+
+    const req = {
+      user: user,
+      params: {
+        id: run._id.toString()
+      }
+    }
+
+    const res = {
+      sendStatus: jest.fn,
+      json: jest.fn,
+    }
+
+    await deleteRun(req, res)
+
+    const runs = await RunModel.find({}).exec()
+    expect(runs.length).toBe(0)
+
+    const dsList = await DailyStatsModel.find({}).exec()
+    expect(dsList.length).toBe(0)
+
+    const plans = await TrainingModel.find({}).exec()
+    expect(plans.length).toBe(1)
+
+    const plan = plans[0]
+    expect(plan.actualDistance).toBe(0)
+    expect(plan.plannedDistance).toBe(1)
+    expect(plan.plannedDistanceMeters).toBe(1609.34)
+    expect(plan.weeks[0].actualDistance).toBe(0)
+    expect(plan.weeks[0].plannedDistance).toBe(1)
+    expect(plan.weeks[0].plannedDistanceMeters).toBe(1609.34)
+    expect(plan.dates[0].actualDistance).toBe(0)
+    expect(plan.dates[0].plannedDistance).toBe(1)
+    expect(plan.dates[0].plannedDistanceMeters).toBe(1609.34)
+  })
+})

--- a/runs/getAllRuns.js
+++ b/runs/getAllRuns.js
@@ -2,12 +2,12 @@ import RunModel from '../db/RunModel.js'
 
 // Returns the logged in user's runs from the database.
 const getAllRuns = async (req, res) => {
-  if (req.user == null || req.user.id == null) {
+  if (req.user == null || req.user._id == null) {
     console.error('UserId is required for this route')
     return res.sendStatus(400)
   }
 
-  const runsArray = await RunModel.find({ userId: req.user.id }).lean()
+  const runsArray = await RunModel.find({ userId: req.user._id }).lean()
 
   // Turn it into a map like {runId: {runField1: runValue1, ... }} so it's easier to lookup a single
   // run object, update it, etc.

--- a/runs/getStravaRuns.js
+++ b/runs/getStravaRuns.js
@@ -4,10 +4,10 @@ import { useFreshTokens } from '../auth/stravaTokens.js'
 
 const getStravaRuns = async (req, res) => {
   try {
-    const user = await UserModel.findById(req.user.id)
+    const user = await UserModel.findById(req.user._id)
 
     if (user == null) {
-      console.error(`Unable to find user with id "${req.user.id}"`)
+      console.error(`Unable to find user with id "${req.user._id}"`)
       return res.sendStatus(400)
     }
 

--- a/runs/updateRun.js
+++ b/runs/updateRun.js
@@ -44,7 +44,7 @@ const updateRun = async (req, res) => {
       try {
         await DailyStatsModel.update(
           {
-            userId: req.user.id,
+            userId: req.user._id,
             runIds: {
               $eq: [run._id] // Only this run ID - otherwise title is still "multiple runs"
             }
@@ -62,7 +62,7 @@ const updateRun = async (req, res) => {
     // Update the user's shoe distance if the shoe was added to the run for the first time.
     if (field === 'shoeId') {
       try {
-        await updateUserShoeList(req.user.id, value, currentValue, run._id, run.distance)
+        await updateUserShoeList(req.user._id, value, currentValue, run._id, run.distance)
       } catch (err) {
         console.error(`Error while attempting to update user shoe list for run with id "${run._id}"`)
         console.dir(err)

--- a/runs/updateUserShoeList.test.js
+++ b/runs/updateUserShoeList.test.js
@@ -8,7 +8,7 @@ import updateUserShoeList from './updateUserShoeList.js'
 beforeAll(async () => {
   // Set up test DB
   try {
-    await mongoose.connect('mongodb://localhost/runs', {
+    await mongoose.connect('mongodb://localhost/updateUserShoeList', {
       useNewUrlParser: true,
       useUnifiedTopology: true
     })
@@ -40,6 +40,7 @@ describe('User can add a shoes to a run', () => {
       email: 'lenin@gmail.com',
       gear: {
         shoes: [{
+          _id: mongoose.Types.ObjectId(),
           title: 'First shoe',
           distance: 0,
           runIds: [],
@@ -144,11 +145,13 @@ describe('User can add a shoes to a run', () => {
         gear: {
           shoes: [
             {
+              _id: user.gear.shoes[0]._id,
               title: 'First shoe',
               distance: run1.distance,
               runIds: [run1._id],
             },
             {
+              _id: user.gear.shoes[1]._id,
               title: 'Second shoe',
               distance: 0,
               runIds: [],
@@ -201,6 +204,7 @@ describe('User can add a shoes to a run', () => {
         gear: {
           shoes: [
             {
+              _id: user.gear.shoes[0]._id,
               title: 'First shoe',
               distance: run1.distance,
               runIds: [run1._id],

--- a/scripts/mongo/initializeDailyStats.js
+++ b/scripts/mongo/initializeDailyStats.js
@@ -1,10 +1,7 @@
 import connectToMongo from '../../db/connectToMongo.js'
 import disconnectFromMongo from '../../db/disconnectFromMongo.js'
 import UserModel from '../../db/UserModel.js'
-import RunModel from '../../db/RunModel.js'
-import DailyStatsModel from '../../db/DailyStatsModel.js'
-import { DateTime } from 'luxon'
-import addFloats from '../../utils/addFloats.js'
+import resetDailyStats from '../../dailystats/resetDailyStats.js'
 
 // This script adds documents to the DailyStats collection based on the existing run data
 
@@ -31,133 +28,10 @@ const initializeDailyStats = async () => {
 
   // For each user, for each unique day with a run, add a DailyStats document.
   for (let i = 0; i < allUsers.length; i++) {
-    let user = allUsers[i]
-    const userId = user._id
-
-    console.log(`Creating DailyStats for user: ${userId}`)
-    console.dir(user)
-
-    let allRuns
     try {
-      allRuns = await RunModel.find(
-        { userId: userId }, // all runs for this user
-        '_id startDate timezone distance title'
-      ).lean()
+      await resetDailyStats(allUsers[i], true)
     } catch (err) {
       console.error(err)
-    }
-
-    console.log(`Found ${allRuns.length} runs for user`)
-
-    // Add a DailyStats document for each unique date with a run, and populate the DailyStats fields
-    // with correct distance totals and runIds
-    let dailyStats = {}
-    for (let j = 0; j < allRuns.length; j++) {
-      let run = allRuns[j]
-
-      // Timeone field has a weird format like "(GMT-07:00) America/Denver", just ignore the offset
-      const tz = run.timezone.split(' ')[1]
-
-      // Convert the run's full timestamp into a simpler yyyy-mm-dd date string
-      const startDate = DateTime.fromJSDate(run.startDate, { zone: tz }).toISODate()
-
-      // Is there is a DailyStats object with this run's startDate already?
-      if (Object.keys(dailyStats).includes(startDate)) {
-        // Add the distance to the existing distance for today
-        dailyStats[startDate] = {
-          ...dailyStats[startDate],
-          distance: addFloats(dailyStats[startDate].distance, run.distance),
-          title: 'Multiple runs',
-          runIds: [
-            ...dailyStats[startDate].runIds,
-            run._id
-          ]
-        }
-      } else {
-        // Make a new entry for this date and set the distance field appropriately
-        dailyStats[startDate] = {
-          userId: userId,
-          date: startDate,
-          distance: run.distance,
-          title: run.title,
-          runIds: [run._id],
-
-          // Add these fields later when we know which dates exist and their daily distance totals
-          sevenDayDistance: 0,
-          weeklyDistance: 0,
-        }
-      }
-    }
-
-    // Determine 7day distance
-    //   - Today's distance + all of the previous day's distances until 6 days ago (inclusive)
-    // Determine weekly distance
-    //   - Today's distance + all of the previous day's distances until the first day of the week (inclusive) as 
-    //     determined by the user.stats.weekStartsOn field
-
-    console.log(`User's week starts on: ${user.stats.weekStartsOn}`)
-    console.log('~~~~~~~~~~~~~~~~~~~~~')
-
-    // Using the existing daily distance totals, calculate the derivative distance fields
-    const dates = Object.keys(dailyStats)
-    for (let i = 0; i < dates.length; i++) {
-      // "Current" date refers to the date whose 7day and weekly distances we want to find
-      const currentDailyStats = dailyStats[dates[i]]
-      const currentDate = DateTime.fromISO(currentDailyStats.date)
-      let hitStartOfWeek = currentDate.weekday === user.stats.weekStartsOn // Set to true once first day of this week is found
-
-      console.log(`DailyStats date: ${dates[i]}`)
-      console.log(`weekday: ${currentDate.weekday}`)
-      console.log('~~~~~~~~~~~~~~~~~~~~~')
-      
-
-      // Values we're trying to calculate
-      currentDailyStats.sevenDayDistance = currentDailyStats.distance
-      currentDailyStats.weeklyDistance = currentDailyStats.distance
-
-      // Find the 6 previous days (-1 to -6) based on the current date we're looking at
-      for (let dayOffset = 1; dayOffset <= 6; dayOffset++) {
-        let date = currentDate.minus({ day: dayOffset })
-        const dateStr = date.toISODate()
-
-        console.log(`date: ${dateStr} / weekday: ${date.weekday}`)
-
-        // Does a dailyStats record exist for this date?
-        if (dailyStats[dateStr] != null) {
-          // 7-day distance is just the sum of all distance for previous 6 days
-          console.log('    adding to 7day total')
-          currentDailyStats.sevenDayDistance += dailyStats[dateStr].distance
-
-          // Have we hit the start of this week yet? If so, do not add this to the weekly distance
-          if (!hitStartOfWeek) {
-            console.log('    adding to weekly total')
-
-            // Update the halting flag, then add this date's distance to the weekly sum.
-            hitStartOfWeek = date.weekday === user.stats.weekStartsOn
-            currentDailyStats.weeklyDistance += dailyStats[dateStr].distance
-          }
-        } else if (!hitStartOfWeek) {
-          // Even if the dailyStats object doesn't exist, we should see if this date is the first
-          // one of the week.
-          hitStartOfWeek = date.weekday === user.stats.weekStartsOn
-        }
-      }
-    }
-
-    console.log('\n\n\n')
-    console.log('Inserting DS into mongo for this user:')
-
-    for (let ds of Object.values(dailyStats)) {
-      // Insert the user's DailyStats documents to the collection
-      try {
-        // Bulk insert all of the DailyStats objects you made out of the runs
-        console.log(ds.date)
-        await DailyStatsModel.insertMany(ds)
-      } catch (err) {
-        console.error('Failed to insert this ds:')
-        console.dir(ds)
-        console.error(err)
-      } 
     }
   }
 

--- a/training/createTrainingPlan.js
+++ b/training/createTrainingPlan.js
@@ -8,9 +8,9 @@ import updatePlanActualDistances from '../training/updatePlanActualDistances.js'
 const createTrainingPlan = async (req, res) => {
   // Parse the required and optional fields, then validate them
   const startDate = req.body.startDate // ISO Date like yyyy-mm-dd
-  const startDT = DateTime.fromISO(req.body.startDate)
+  const startDT = DateTime.fromISO(req.body.startDate, { zone: 'utc' }).startOf('day')
   const endDate = req.body.endDate // ISO Date like yyyy-mm-dd
-  const endDT = DateTime.fromISO(req.body.endDate)
+  const endDT = DateTime.fromISO(req.body.endDate, { zone: 'utc' }).startOf('day')
   const weekCount = req.body.weekCount
   const timezone = req.body.timezone
   const title = req.body.title
@@ -78,7 +78,7 @@ const createTrainingPlan = async (req, res) => {
   }
 
   let newPlan = {
-    userId: req.user.id,
+    userId: req.user._id,
     startDate: startDate,
     endDate: endDate,
     weekCount: weekCount,

--- a/training/createTrainingPlan.test.js
+++ b/training/createTrainingPlan.test.js
@@ -124,7 +124,7 @@ describe('Training creation', () => {
     // Now test if the creation function works, not just the db
     const req = {
       user: {
-        id: user._id,
+        _id: user._id,
       },
       body: {
         startDate: '2022-10-10',
@@ -189,7 +189,7 @@ describe('Training creation', () => {
     // Request to create 1-week training plan during week of the runs
     const req = {
       user: {
-        id: user._id,
+        _id: user._id,
       },
       body: {
         startDate: '2022-10-10',
@@ -271,7 +271,7 @@ describe('Training creation', () => {
     // Request to create 1-week training plan during week of the runs
     const req = {
       user: {
-        id: user._id,
+        _id: user._id,
       },
       body: {
         startDate: '2022-10-10',

--- a/training/getAllTrainingPlans.js
+++ b/training/getAllTrainingPlans.js
@@ -2,7 +2,7 @@ import TrainingModel from '../db/TrainingModel.js'
 
 // Returns the logged in user's training plans from the database.
 const getAllTrainingPlans = async (req, res) => {
-  const trainingPlans = await TrainingModel.find({ userId: req.user.id }).lean()
+  const trainingPlans = await TrainingModel.find({ userId: req.user._id }).lean()
 
   // Turn it into a map like {trainingId: {trainingField1: trainingValue1, ... }} so it's easier to
   // lookup a single training plan object, update it, etc.

--- a/training/updatePlanActualDistances.test.js
+++ b/training/updatePlanActualDistances.test.js
@@ -22,198 +22,6 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   jest.spyOn(console, 'log').mockImplementation(() => {}) // Ignores console.log, keeps others
-
-  // These tests use the same initial database state
-  const user = await UserModel.create({
-    name: 'Vlad',
-    email: 'lenin@gmail.com'
-  })
-
-  const notUser = await UserModel.create({
-    name: 'Not the plan user',
-    email: 'not@gmail.com'
-  })
-
-  // Only need to create the dailystats - runs aren't necessary for calculations
-  await DailyStatsModel.create({
-    userId: user._id,
-    date: '2022-10-10',
-    distance: 1000.01,
-  })
-
-  await DailyStatsModel.create({
-    userId: user._id,
-    date: '2022-10-17',
-    distance: 1000.02,
-  })
-
-  await DailyStatsModel.create({
-    userId: user._id,
-    date: '2022-10-18',
-    distance: 1000.03,
-  })
-
-  // Counts should NOT include these DS distances
-  await DailyStatsModel.create({
-    userId: user._id,
-    date: '2022-10-24', // after plan date range
-    distance: 1001,
-  })
-
-  await DailyStatsModel.create({
-    userId: user._id,
-    date: '2022-10-09', // before plan date range
-    distance: 1002,
-  })
-
-  await DailyStatsModel.create({
-    userId: notUser._id, // Not the right user
-    date: '2022-10-10',
-    distance: 1003,
-  })
-
-  // Create a plan that we can use to test if the actualDistance fields were set correctly
-  await TrainingModel.create({
-    userId: user._id,
-    startDate: '2022-10-10',
-    endDate: '2022-10-23',
-    timezone: 'America/Denver',
-    title: 'Training Plan 2 Weeks',
-    goal: 'Update training plans actual distances',
-    isActive: true,
-    actualDistance: 0,
-    plannedDistance: 0,
-    plannedDistanceMeters: 0,
-    weeks: [
-      {
-        startDateISO: '2022-10-10',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-      },
-      {
-        startDateISO: '2022-10-17',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-      }
-    ],
-    dates: [
-      {
-        dateISO: '2022-10-10',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-11',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-12',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-13',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-14',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-15',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-16',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-17',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-18',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-19',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-20',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-21',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-22',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-      {
-        dateISO: '2022-10-23',
-        actualDistance: 0,
-        plannedDistance: 0,
-        plannedDistanceMeters: 0,
-        workout: '',
-        workoutCategory: 0,
-      },
-    ],
-    journal: []
-  })
 })
 
 afterEach(async () => {
@@ -230,17 +38,210 @@ afterAll(async () => {
 
 describe('Plan actualDistance recalculation function', () => {
   test('Actual distance fields are summed from DailyStats appropriately', async () => {
+    // These tests use the same initial database state
+    const user = await UserModel.create({
+      name: 'Vlad',
+      email: 'lenin@gmail.com'
+    })
+
+    const notUser = await UserModel.create({
+      name: 'Not the plan user',
+      email: 'not@gmail.com'
+    })
+
+    // Only need to create the dailystats - runs aren't necessary for calculations
+    await DailyStatsModel.create({
+      userId: user._id,
+      date: '2022-10-10',
+      distance: 1000.01,
+    })
+
+    await DailyStatsModel.create({
+      userId: user._id,
+      date: '2022-10-17',
+      distance: 1000.02,
+    })
+
+    await DailyStatsModel.create({
+      userId: user._id,
+      date: '2022-10-18',
+      distance: 1000.03,
+    })
+
+    // Counts should NOT include these DS distances
+    await DailyStatsModel.create({
+      userId: user._id,
+      date: '2022-10-24', // after plan date range
+      distance: 1001,
+    })
+
+    await DailyStatsModel.create({
+      userId: user._id,
+      date: '2022-10-09', // before plan date range
+      distance: 1002,
+    })
+
+    await DailyStatsModel.create({
+      userId: notUser._id, // Not the right user
+      date: '2022-10-10',
+      distance: 1003,
+    })
+
+    // Create a plan that we can use to test if the actualDistance fields were set correctly
+    await TrainingModel.create({
+      userId: user._id,
+      startDate: '2022-10-10',
+      endDate: '2022-10-23',
+      timezone: 'America/Denver',
+      title: 'Training Plan 2 Weeks',
+      goal: 'Update training plans actual distances',
+      isActive: true,
+      actualDistance: 0,
+      plannedDistance: 0,
+      plannedDistanceMeters: 0,
+      weeks: [
+        {
+          startDateISO: '2022-10-10',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+        },
+        {
+          startDateISO: '2022-10-17',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+        }
+      ],
+      dates: [
+        {
+          dateISO: '2022-10-10',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-11',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-12',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-13',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-14',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-15',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-16',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-17',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-18',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-19',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-20',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-21',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-22',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+        {
+          dateISO: '2022-10-23',
+          actualDistance: 0,
+          plannedDistance: 0,
+          plannedDistanceMeters: 0,
+          workout: '',
+          workoutCategory: 0,
+        },
+      ],
+      journal: []
+    })
+
     const plan = await TrainingModel.findOne({}).exec()
 
-    await updatePlanActualDistances(plan)
+    // TODO: updatePlanActualDistances RETURNS the plan for you to deal with - it doesn't hit the db
+    let updatedPlan = await updatePlanActualDistances(plan)
 
-    expect(plan.actualDistance).toBe(3000.06)
-    expect(plan.weeks[0].actualDistance).toBe(1000.01)
-    expect(plan.weeks[1].actualDistance).toBe(2000.05)
-    expect(plan.dates[0].actualDistance).toBe(1000.01)
-    expect(plan.dates[1].actualDistance).toBe(0)
-    expect(plan.dates[7].actualDistance).toBe(1000.02)
-    expect(plan.dates[8].actualDistance).toBe(1000.03)
-    expect(plan.dates[9].actualDistance).toBe(0)
+    expect(updatedPlan.actualDistance).toBe(3000.06)
+    expect(updatedPlan.weeks[0].actualDistance).toBe(1000.01)
+    expect(updatedPlan.weeks[1].actualDistance).toBe(2000.05)
+    expect(updatedPlan.dates[0].actualDistance).toBe(1000.01)
+    expect(updatedPlan.dates[1].actualDistance).toBe(0)
+    expect(updatedPlan.dates[7].actualDistance).toBe(1000.02)
+    expect(updatedPlan.dates[8].actualDistance).toBe(1000.03)
+    expect(updatedPlan.dates[9].actualDistance).toBe(0)
   })
 })

--- a/training/updateTrainingPlan.test.js
+++ b/training/updateTrainingPlan.test.js
@@ -219,7 +219,7 @@ describe('Training Plan is updated', () => {
     // Request to update existing training plan's dates
     const req = {
       user: {
-        id: user._id,
+        _id: user._id,
       },
       params: {
         id: plan._id,
@@ -389,7 +389,7 @@ describe('Training Plan is updated', () => {
     // plannedDistanceMeters field should always be ignored by endpoint
     const req = {
       user: {
-        id: user._id,
+        _id: user._id,
       },
       params: {
         id: plan._id,

--- a/training/updateTrainingPlanDate.test.js
+++ b/training/updateTrainingPlanDate.test.js
@@ -219,7 +219,7 @@ describe('Training Plan date update endpoint', () => {
     // Request to update existing training plan's dates
     const req = {
       user: {
-        id: user._id,
+        _id: user._id,
       },
       params: {
         id: plan._id,

--- a/users/createShoes.js
+++ b/users/createShoes.js
@@ -9,7 +9,7 @@ const createShoes = async (req, res) => {
     return res.status(400).json({ error: 'Unable to create training plan: title must be a string'})
   }
 
-  if (req.user == null || req.user.id == null) {
+  if (req.user == null || req.user._id == null) {
     return res.status(500).json({ error: 'Unable to add shoes to user: user not found.' })
   }
 
@@ -22,10 +22,10 @@ const createShoes = async (req, res) => {
   // Get the user object and add the shoes to it
   let user
   try {
-    user = await UserModel.findById(req.user.id)
+    user = await UserModel.findById(req.user._id)
 
     if (user == null) {
-      console.error(`Unable to find user with id "${req.user.id}"`)
+      console.error(`Unable to find user with id "${req.user._id}"`)
       return res.sendStatus(400)
     }
 
@@ -40,7 +40,7 @@ const createShoes = async (req, res) => {
     user = await user.save()
 
     return res.json({
-      id: user.id,
+      id: user._id,
       name: user.name,
       email: user.email,
       hasFitbitAuth: user.hasFitbitAuth || false,

--- a/users/deleteShoes.js
+++ b/users/deleteShoes.js
@@ -4,7 +4,7 @@ import RunModel from '../db/RunModel.js'
 // Removes the given run from the database
 const deleteShoes = async (req, res) => {
   try {
-    const user = await UserModel.findById(req.user.id)
+    const user = await UserModel.findById(req.user._id)
 
     if (user == null) {
       console.error('Cannot delete shoes: user was not found.')
@@ -44,10 +44,10 @@ const deleteShoes = async (req, res) => {
 
     await user.save()
 
-    console.log(`Deleted shoes from user "${req.user.id}", with shoe id "${req.params.shoeId}"`)
+    console.log(`Deleted shoes from user "${req.user._id}", with shoe id "${req.params.shoeId}"`)
 
     return res.json({
-      id: user.id,
+      _id: user._id,
       name: user.name,
       email: user.email,
       hasFitbitAuth: user.hasFitbitAuth || false,

--- a/users/deleteShoes.test.js
+++ b/users/deleteShoes.test.js
@@ -8,7 +8,7 @@ import deleteShoes from './deleteShoes.js'
 beforeAll(async () => {
   // Set up test DB
   try {
-    await mongoose.connect('mongodb://localhost/runs', {
+    await mongoose.connect('mongodb://localhost/updateUserShoeList', {
       useNewUrlParser: true,
       useUnifiedTopology: true
     })
@@ -41,6 +41,7 @@ describe('User can add a shoes to a run', () => {
       gear: {
         shoes: [
           {
+            _id: mongoose.Types.ObjectId(),
             title: 'First shoe',
             distance: 0,
             runIds: [],
@@ -61,6 +62,7 @@ describe('User can add a shoes to a run', () => {
 
     user.gear.shoes = [
       {
+        _id: user.gear.shoes[0]._id,
         title: 'First shoe',
         distance: run.distance,
         runIds: [run._id],

--- a/users/deleteShoes.test.js
+++ b/users/deleteShoes.test.js
@@ -8,7 +8,7 @@ import deleteShoes from './deleteShoes.js'
 beforeAll(async () => {
   // Set up test DB
   try {
-    await mongoose.connect('mongodb://localhost/updateUserShoeList', {
+    await mongoose.connect('mongodb://localhost/deleteShoes', {
       useNewUrlParser: true,
       useUnifiedTopology: true
     })

--- a/users/getUserDetails.js
+++ b/users/getUserDetails.js
@@ -11,23 +11,23 @@ const getUserDetails = async (req, res) => {
   }
 
   // Make sure the authenticated user is the one whose details are being requested
-  if (req.user.id !== req.params.id) {
+  if (req.user._id !== req.params.id) {
     // TODO: allow admin users to skip this check
-    console.error(`User with id "${req.user.id} is forbidden from accessing user details for user id: "${req.params.id}"`)
+    console.error(`User with id "${req.user._id} is forbidden from accessing user details for user id: "${req.params.id}"`)
     return res.sendStatus(403)
   }
 
   try {
     // Look up user by email in mongo
-    const user = await UserModel.findById(req.user.id)
+    const user = await UserModel.findById(req.user._id)
 
     if (user == null) {
-      console.error(`Unable to find user with id "${req.user.id}"`)
+      console.error(`Unable to find user with id "${req.user._id}"`)
       return res.sendStatus(400)
     }
 
     return res.json({
-      id: user.id,
+      _id: user._id,
       name: user.name,
       email: user.email,
       hasFitbitAuth: user.hasFitbitAuth || false,


### PR DESCRIPTION
- Tests to cover run deletion
- DailyStats will be removed if the only run for the day is deleted
- Plan actualDistance fields (plan, week, date) will be updated to reflect accurate distances
- User object as req.user will use `user._id` instead of an (anomalously named?) `id` field. Front end references are updated as well
- Fixes training plan creation bug
- Some unrelated tests are fixed