### PR TITLE
Add startLocation field to RunModel.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    browser: true,
+    node: true,
     es2021: true,
   },
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],

--- a/db/RunModel.js
+++ b/db/RunModel.js
@@ -24,6 +24,7 @@ const runSchema = new mongoose.Schema({
   // https://mongoosejs.com/docs/geojson.html
   startLatitude: Number,
   startLongitude: Number,
+  startLocation: String, // Reverse geocoded location string based on start lat/lng
 
   // User editable fields
   results: { type: String, default: null },

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ app.delete('/api/v1/training/:id', authenticateToken, deleteTrainingPlan)
 // LOGIN ROUTES
 
 // For now, there is no way to create a user account except via the database.
-// See scripts/createUser.js
+// See scripts/addUser.js
 
 // This route is for providing user information to the client if they already have a JWT.
 app.get('/api/v1/users/:id', authenticateToken, getUserDetails)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "log-timestamp": "^0.3.0",
     "luxon": "^3.4.3",
     "mongoose": "^7.5.2",
-    "qs": "^6.11.2"
+    "qs": "^6.11.2",
+    "reverse-geocode": "^1.3.3"
   },
   "devDependencies": {
     "eslint": "8.55.0",
@@ -65,6 +66,7 @@
     "trailingComma": "es5",
     "semi": false,
     "singleQuote": true,
-    "jsxSingleQuote": true
+    "jsxSingleQuote": true,
+    "arrowParens": "avoid"
   }
 }

--- a/runs/createRunFromStravaActivity.js
+++ b/runs/createRunFromStravaActivity.js
@@ -1,6 +1,7 @@
 import RunModel from '../db/RunModel.js'
 
 import generateTitle from './generateTitle.js'
+import generateLocation from './generateLocation.js'
 import updateDailyStats from '../dailyStats/updateDailyStats.js'
 import updatePlansFromRun from './updatePlansFromRun.js'
 
@@ -29,6 +30,10 @@ const createRunFromStravaActivity = async (user, activity) => {
       // Format should be like '(GMT-08:00) America/Denver', luxon wants just the latter half
       const tz = activity.timezone.split(' ')[1]
 
+      const lat = activity?.start_latlng[0]
+      const lng = activity?.start_latlng[1]
+      const location = generateLocation(lat, lng)
+
       const newRun = await RunModel.create({
         userId: user._id,
         name: activity.name,
@@ -46,8 +51,9 @@ const createRunFromStravaActivity = async (user, activity) => {
         deviceName: activity.device_name,
         stravaActivityId: activity.id,
         stravaExternalId: activity.external_id,
-        startLatitude: activity?.start_latlng[0],
-        startLongitude: activity?.start_latlng[1],
+        startLatitude: lat,
+        startLongitude: lng,
+        startLocation: location,
       })
 
       console.log(

--- a/runs/generateLocation.js
+++ b/runs/generateLocation.js
@@ -1,0 +1,11 @@
+import reverse from 'reverse-geocode'
+
+// Given a run start lat/lng, returns a location string describing where this
+// run began.
+const generateLocation = (lat, lng) => {
+  const result = reverse.lookup(lat, lng, 'us')
+
+  return `${result.city}, ${result.state_abbr}`
+}
+
+export default generateLocation

--- a/scripts/mongo/addStartLocationFieldToRuns.js
+++ b/scripts/mongo/addStartLocationFieldToRuns.js
@@ -1,0 +1,47 @@
+import connectToMongo from '../../db/connectToMongo.js'
+import disconnectFromMongo from '../../db/disconnectFromMongo.js'
+import RunModel from '../../db/RunModel.js'
+import generateLocation from '../../runs/generateLocation.js'
+
+// This script adds a string field `startLocation` to all run objects. The value
+// is added to each existing run based on the same logic (at time of writing) as
+// used in the createRunFromStravaActivity function.
+
+const addStartLocationFieldToRuns = async () => {
+  connectToMongo()
+
+  // Get each run document, figure out the correct location using startLatitude and startLongitude, save run.
+
+  try {
+    const allRuns = await RunModel.find(
+      {}, // all runs
+      '_id startLatitude startLongitude'
+    )
+
+    // Add the startLocation field to this run document
+    let nModified = 0
+    for (let i = 0; i < allRuns.length; i++) {
+      let run = allRuns[i]
+
+      run.startLocation = generateLocation(
+        run._doc.startLatitude,
+        run._doc.startLongitude
+      )
+
+      try {
+        await run.save()
+        nModified++
+      } catch (err) {
+        console.error(err)
+      }
+    }
+
+    console.log(`${allRuns.length} runs found, ${nModified} updated.`)
+  } catch (err) {
+    console.error(err)
+  } finally {
+    disconnectFromMongo()
+  }
+}
+
+addStartLocationFieldToRuns()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3146,6 +3146,11 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+reverse-geocode@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/reverse-geocode/-/reverse-geocode-1.3.3.tgz#afc3d7efc7cc65c33f6c7c656a7623ff5921477a"
+  integrity sha512-xfFKCmCjLk/WyEtsyZycZwlRiV02alFIjWv/yoTamolLFtWwAGTfk15BhaLblXvMpf+nwrfalzH+3jxc7g+8gA==
+
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"


### PR DESCRIPTION
- Add `reverse-geocode` package to look up city and state given lat/lng.
- Add `generateLocation` function to handle this lookup. 
- Add `scripts/mongo/addStartLocationFieldToRuns.js` to initialize this new field for existing runs
- Add `startLocation` field to `createRunFromStravaActivity` for when new runs are sent from the Strava webhook.